### PR TITLE
#1 基本となる openapi.yaml の作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,42 @@ OpenAPI を使用するにあたっての実際のコードなど
 
 [ベースの gist](https://gist.github.com/ysKuga/9664fd61cd2315af8fe8dbddbff371c4)
 
+## 構成
+
+以下の記事を参考に `openapi/basic/` を構成
+
+<https://tech.buysell-technologies.com/entry/2021/09/21/095238>
+
+### `tags`
+
+`tags` の指定によりその数だけ `～Api` が生成されるため、特に理由がなければ統一する。
+
+```yaml
+get:
+  tags:
+    - basic
+```
+
+### `paths/`
+
+`openapi.yaml` にて `paths` プロパティのパスに `$ref` を指定
+
+```yaml
+paths:
+  /product/{id}:
+    $ref: ./paths/product-[id].yaml
+```
+
+- パス内クエリについては `[{変数名}]` の形式とし、スラッシュをハイフンに (とりあえず)
+  - `/product/{id}` -> `paths/product-[id].yaml`
+
+### `schemas/`
+
+`openapitools/openapi-generator-cli` による型生成の都合により以下のようにする。
+
+- ケバブケースでファイルを定義
+  - ファイル名がパスカルケースに変換されて型が生成されるため
+
 ## 課題
 
 ### `paths/` 配下でのエラー表示

--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@
 OpenAPI を使用するにあたっての実際のコードなど
 
 [ベースの gist](https://gist.github.com/ysKuga/9664fd61cd2315af8fe8dbddbff371c4)
+
+## 課題
+
+### `paths/` 配下でのエラー表示
+
+`paths/` 配下にて以下のような記述をした際にエラー表示が出てしまう。
+
+```yaml
+get:
+  tags:
+    - basic
+```
+
+現状エラー解消を行う方法が見つけられていない。
+
+```log
+Property tags is not allowed.yaml-schema: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json
+```

--- a/openapi/basic/README.md
+++ b/openapi/basic/README.md
@@ -1,0 +1,5 @@
+# apis/basic/
+
+以下の記事を参考
+
+<https://tech.buysell-technologies.com/entry/2021/09/21/095238>

--- a/openapi/basic/openapi.yaml
+++ b/openapi/basic/openapi.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: OpenAPI のベース
+  description: OpenAPI のファイルをサンプルとして作成
+  version: 1.0.0
+servers:
+  - url: "{server}"
+    description: URL 一覧
+    variables:
+      server:
+        default: http://localhost:3000
+tags:
+  - name: basic
+paths:
+  /product/{id}:
+    $ref: ./paths/product-[id].yaml

--- a/openapi/basic/openapi.yaml
+++ b/openapi/basic/openapi.yaml
@@ -14,3 +14,5 @@ tags:
 paths:
   /product/{id}:
     $ref: ./paths/product-[id].yaml
+  /product-test/{id}:
+    $ref: ./paths/product-test-[id].yaml

--- a/openapi/basic/paths/product-[id].yaml
+++ b/openapi/basic/paths/product-[id].yaml
@@ -1,0 +1,25 @@
+get:
+  tags:
+    - basic
+  summary: ID による製品取得
+  description: 製品を 1 件返す
+  operationId: getProductById
+  parameters:
+    - name: id
+      in: path
+      description: product id
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: 成功時
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/product.yaml
+          example:
+            id: 1
+            name: 製品 A
+            is_limited: false
+            released_at: 2021/09/01

--- a/openapi/basic/paths/product-[id].yaml
+++ b/openapi/basic/paths/product-[id].yaml
@@ -17,9 +17,13 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../schemas/product.yaml
+            $ref: "#/components/schemas/product"
           example:
             id: 1
             name: 製品 A
             is_limited: false
             released_at: 2021/09/01
+components:
+  schemas:
+    product:
+      $ref: ../schemas/product.yaml

--- a/openapi/basic/paths/product-test-[id].yaml
+++ b/openapi/basic/paths/product-test-[id].yaml
@@ -1,0 +1,29 @@
+get:
+  tags:
+    - basic
+  summary: ID による製品取得
+  description: 製品を 1 件返す
+  operationId: getProductTestById
+  parameters:
+    - name: id
+      in: path
+      description: product id
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: 成功時
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/product-test"
+          example:
+            id: 1
+            name: 製品 A
+            is_limited: false
+            released_at: 2021/09/01
+components:
+  schemas:
+    product-test:
+      $ref: ../schemas/product-test.yaml

--- a/openapi/basic/schemas/product-test.yaml
+++ b/openapi/basic/schemas/product-test.yaml
@@ -1,0 +1,26 @@
+type: object
+description: テスト製品
+properties:
+  id:
+    type: integer
+    description: テスト製品の ID
+    example: 1
+  name:
+    type: string
+    description: 製品名
+    example: 製品 A
+  type:
+    type: string
+    description: タイプ
+    example: タイプ A
+  is_limited:
+    type: boolean
+    description: 限定販売かどうか
+    example: false
+  released_at:
+    type: string
+    description: 発売日
+    example: 2021/09/01
+required:
+  - id
+  - name

--- a/openapi/basic/schemas/product.yaml
+++ b/openapi/basic/schemas/product.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: 製品の ID
+    example: 1
+  name:
+    type: string
+    description: 製品名
+    example: 製品 A
+  is_limited:
+    type: boolean
+    description: 限定販売かどうか
+    example: false
+  released_at:
+    type: string
+    description: 発売日
+    example: 2021/09/01

--- a/openapi/basic/schemas/product.yaml
+++ b/openapi/basic/schemas/product.yaml
@@ -1,4 +1,5 @@
 type: object
+description: 製品
 properties:
   id:
     type: integer
@@ -16,3 +17,5 @@ properties:
     type: string
     description: 発売日
     example: 2021/09/01
+required:
+  - id


### PR DESCRIPTION
# #1 基本となる openapi.yaml の作成

以下の記事を参考に openapi.yaml の作成

<https://tech.buysell-technologies.com/entry/2021/09/21/095238>

## 対応

- [x] `openapi/basic/` 配下に openapi.yaml の作成を行う。
